### PR TITLE
Disable autoCorrect and autocapitalise on url TextFields

### DIFF
--- a/src/components/Fields.jsx
+++ b/src/components/Fields.jsx
@@ -22,10 +22,11 @@ export function TextField({
   placeholder,
   callback,
   defaultValue,
+  className,
   ...props
 }) {
   return (
-    <div className={props.className}>
+    <div className={className}>
       {label && <Label id={id}>{label}</Label>}
       <input
         placeholder={placeholder}
@@ -33,6 +34,7 @@ export function TextField({
         id={id}
         defaultValue={defaultValue}
         {...register(name, { onChange: (e) => callback(name, e) })}
+        {...props}
       />
       {error && !alternative && <span className="mt-2 inline-block text-xs text-red-600">{error.message}</span>}
     </div>

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -98,6 +98,8 @@ export default function Form(props) {
               id="plugin-uri"
               name="pluginUri"
               type="text"
+              autoCorrect="off"
+              autoCapitalize="none"
               alternative={true}
               register={register}
               error={errors.pluginUri}
@@ -144,6 +146,8 @@ export default function Form(props) {
               name="authorUri"
               type="text"
               placeholder="Author URL"
+              autoCorrect="off"
+              autoCapitalize="none"
               alternative={true}
               register={register}
               error={errors.authorUri}


### PR DESCRIPTION
When filling an url in the form using Safari the domain name gets capitalized, which result in this result in the plugin header
<img width="800" alt="Capture d’écran 2022-10-11 à 00 07 54" src="https://user-images.githubusercontent.com/1884246/194959713-129f8092-f6d4-42d2-b010-25d3b79df504.png">
I also modified the TextField component to pass the additional props to the input element 👍 