### PR TITLE
Set temp folder based on operating system

### DIFF
--- a/src/lib/github-download.js
+++ b/src/lib/github-download.js
@@ -11,7 +11,8 @@ var path = require('path')
 var fs = require('fs-extra')
 var util = require('util')
 var extractZip = require('./zip').extractZip
-var cwd = '/tmp'
+var os = require('os')
+var cwd = os.tmpdir()
 
 function GithubDownloader (user, repo, ref, dir) {
   this.user = user

--- a/src/pages/api/generate.js
+++ b/src/pages/api/generate.js
@@ -4,13 +4,14 @@ import ua from 'universal-analytics'
 import replace from 'replace'
 import fs from 'fs-extra'
 import { EasyZip  } from 'easy-zip'
+import os from 'os'
 // Local Libs
 import ghdownload from '../../lib/github-download'
 import getDefaultValues from '../../lib/get-default-values'
 import walker from '../../lib/walker'
 
 const visitor = ua('UA-56742268-1')
-const tmpFolder = '/tmp'
+const tmpFolder = os.tmpdir()
 const source = path.join(tmpFolder, 'source')
 
 let destination


### PR DESCRIPTION
On Windows hosts, /tmp doesn't exist. This pull request sets the temp folder accordingly.